### PR TITLE
fix: handle category duplicate errors and caching

### DIFF
--- a/backend/src/controllers/category.controller.js
+++ b/backend/src/controllers/category.controller.js
@@ -4,6 +4,11 @@ import { clearCache } from '../middleware/cache.js';
 export const create = async (c) => {
   try {
     const category = await categoryService.create(await c.req.json());
+
+    // Clear relevant caches
+    clearCache('categories:all');
+    clearCache('categories:homepage');
+
     return c.json({ success: true, data: category }, 201);
   } catch (error) {
     throw error;

--- a/frontend/src/services/api/categoryApi.ts
+++ b/frontend/src/services/api/categoryApi.ts
@@ -22,7 +22,12 @@ export const categoryApi = {
       method: "POST",
       body: JSON.stringify({ name }),
     });
-    if (!res.ok) throw new Error("Failed to create category");
+    if (!res.ok) {
+      if (res.status === 409) {
+        throw new Error("Category already exists");
+      }
+      throw new Error("Failed to create category");
+    }
     const json = await res.json();
     return json.data;
   },
@@ -49,7 +54,12 @@ export const categoryApi = {
       method: "PUT",
       body: JSON.stringify(data),
     });
-    if (!res.ok) throw new Error("Failed to update category");
+    if (!res.ok) {
+      if (res.status === 409) {
+        throw new Error("Category name already exists");
+      }
+      throw new Error("Failed to update category");
+    }
     const json = await res.json();
     return json.data;
   },


### PR DESCRIPTION
Fixes 409 Conflict error handling in frontend when creating/updating duplicate categories. Adds cache clearing in backend when a new category is created so it appears immediately.